### PR TITLE
Fix banner URLs

### DIFF
--- a/main.js
+++ b/main.js
@@ -198,13 +198,13 @@ var run = function() {
     }
 
     var msg = ["Don't support this website, " + data.message + "!"];
-    msg.push("<a target='_blank' href='https://docs.google.com/spreadsheets/d/1vu0Y0HvadMgG_LN7dF8W7M66oPCcx_nmSARQWirV7iY/htmlview'>Full details here</a>");
+    msg.push("<a target='_blank' href='https://grabyourwallet.org'>Full details here</a>");
 
     var subject = "Please stop supporting Trump";
     var body = "Hi, I'm a customer of your brand. Unfortunately I'll no longer be able to shop there because you do business with the Trump family. If you were to no longer do so I would consider returning as a customer.";
 
     if (data.email) {
-        msg.push("<a target='_blank' href='mailto: " + data.email.join(",") + "?subject=" + subject + "&body=" + body + "'>Email them</a>");
+        msg.push("<a target='_blank' href=\"mailto:" + data.email.join(",") + "?subject=" + subject + "&body=" + body + "\">Email them</a>");
     }
 
     if (data.alternatives) {


### PR DESCRIPTION
The GYW google doc now has it's own domain. Also, the `mailto:` link was broken because the e-mail body includes a single quote and the link `href` attribute was escaped using single quotes instead of double quotes.